### PR TITLE
Add prior art sections to READMEs

### DIFF
--- a/packages/compass/README.md
+++ b/packages/compass/README.md
@@ -32,6 +32,12 @@ nav.firstChild(); // ch-1 → 1.1
 - `wrap` - loop around at the ends (default: true)
 - `leavesOnly` - skip parents, only visit leaves
 
+## Prior Art
+
+- **Roving tabindex** — The accessibility pattern where one item in a widget is tabbable at a time, arrow keys move focus. Compass implements this logic headlessly.
+- **Screen reader navigation** — VoiceOver/NVDA let users jump by granularity (character → word → paragraph → heading). A future direction for Compass.
+- **Emacs buffer list** — Uniform navigation interface for any list (files, search results, commits). Same idea: decouple navigation logic from content.
+
 ## Details
 
 No framework needed. Handles edge cases like wrapping, siblings, and depth-first traversal. See [`src/types.ts`](./src/types.ts) for full API.

--- a/packages/lantern/README.md
+++ b/packages/lantern/README.md
@@ -57,6 +57,11 @@ Include `initScript` before paint to prevent flash of wrong theme:
 <script is:inline set:html={initScript} />
 ```
 
+## Prior Art
+
+- **`prefers-color-scheme`** — The CSS media query that detects OS preference. Lantern builds on this, adding persistence and toggle UI.
+- **next-themes** — Solves the same flash-prevention problem for Next.js. Lantern is framework-agnostic.
+
 ## Convention
 
 - Stores in localStorage key: `theme`

--- a/packages/teleport/README.md
+++ b/packages/teleport/README.md
@@ -33,6 +33,11 @@ Mousetrap.bind('j', () => {
 });
 ```
 
+## Prior Art
+
+- **Vimium** — Browser extension adding Vim-style navigation to any webpage. Teleport is similar but site-specific: it understands your sidebar structure rather than being generic.
+- **GNU Readline** — The library behind bash/REPL input (`Ctrl+a`, `Ctrl+e`, `Ctrl+w`). Emacs-style keybindings some users expect as an alternative to Vim's hjkl.
+
 ## Design Philosophy
 
 **Drop-in for any website.** Teleport is a vanilla JavaScript library that works with any DOM. Just provide CSS selectors and it handles everything else.


### PR DESCRIPTION
## Summary
- **compass**: roving tabindex, screen reader granularity, Emacs buffer list
- **teleport**: Vimium, GNU Readline
- **lantern**: prefers-color-scheme, next-themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)